### PR TITLE
Remove instruções do Timber em release

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,6 +16,13 @@
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable
 
+# Remove Timber from source code :D
+-assumenosideeffects class timber.log.Timber {
+    public static *** v(...);
+    public static *** d(...);
+    public static *** i(...);
+}
+
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile


### PR DESCRIPTION
Remove instruções inúteis do Timber em release :D
Como o CrashlyticsTree usa somente prioridade acima de info... Os logs `Timber.v`, `Timber.d` e `Timber.i` podem ser apagados

Isso faz o código ficar ~levemente~ mais rápido